### PR TITLE
feat: split `assetsPlugin` into separate export

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -1,0 +1,1 @@
+export { assetsPlugin as default } from "./plugin.ts";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
-export { default, serverHandlerPlugin, assetsPlugin } from "./plugin.ts";
+export { default, serverHandlerPlugin } from "./plugins/fullstack.ts";
+export { assetsPlugin } from "./plugin.ts";

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -331,10 +331,8 @@ export function assetsPlugin(pluginOpts?: AssetsPluginOptions): Plugin[] {
         filter: { id: /^\0virtual:fullstack\// },
         async handler(id) {
           if (id === "\0virtual:fullstack/runtime") {
-            return fs.readFileSync(
-              path.join(import.meta.dirname, "runtime.js"),
-              "utf-8",
-            );
+            const runtime = await import("./runtime");
+            return `export const mergeAssets = ${runtime.mergeAssets.toString()};`;
           }
 
           const parsed = parseAssetsVirtual(id);

--- a/src/plugins/fullstack.ts
+++ b/src/plugins/fullstack.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { toNodeHandler } from "srvx/node";
+import { type Plugin, isRunnableDevEnvironment } from "vite";
+import { type AssetsPluginOptions, assetsPlugin } from "../plugin";
+import { getEntrySource } from "./utils";
+
+export type FullstackPluginOptions = AssetsPluginOptions & {
+  /**
+   * @default true
+   */
+  serverHandler?: boolean;
+};
+
+export default function vitePluginFullstack(
+  pluginOpts?: FullstackPluginOptions,
+): Plugin[] {
+  return [...serverHandlerPlugin(pluginOpts), ...assetsPlugin(pluginOpts)];
+}
+
+export function serverHandlerPlugin(
+  pluginOpts?: FullstackPluginOptions,
+): Plugin[] {
+  return [
+    {
+      name: "fullstack:server-handler",
+      apply: () => pluginOpts?.serverHandler !== false,
+      config(userConfig, _env) {
+        return {
+          appType: userConfig.appType ?? "custom",
+        };
+      },
+      configureServer(server) {
+        const name = (pluginOpts?.serverEnvironments ?? ["ssr"])[0]!;
+        const environment = server.environments[name]!;
+        assert(isRunnableDevEnvironment(environment));
+        const runner = environment.runner;
+        return () => {
+          server.middlewares.use(async (req, res, next) => {
+            try {
+              const source = getEntrySource(environment.config);
+              const mod = await runner.import(source);
+              req.url = req.originalUrl ?? req.url;
+              await toNodeHandler(mod.default.fetch)(req, res);
+            } catch (e) {
+              next(e);
+            }
+          });
+        };
+      },
+    },
+  ];
+}

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -19,17 +19,17 @@ export function mergeAssets(
   const entry = args.filter((arg) => arg.entry)?.[0]?.entry;
   const raw: ImportAssetsResultRaw = { entry, js, css };
   return { ...raw, merge: (...args) => mergeAssets(raw, ...args) };
-}
 
-// merging is cumbersome because of `data-vite-dev-id` :(
-function uniqBy<T>(array: T[], key: (item: T) => string): T[] {
-  const seen = new Set<string>();
-  return array.filter((item) => {
-    const k = key(item);
-    if (seen.has(k)) {
-      return false;
-    }
-    seen.add(k);
-    return true;
-  });
+  // merging is cumbersome because of `data-vite-dev-id` :(
+  function uniqBy<T>(array: T[], key: (item: T) => string): T[] {
+    const seen = new Set<string>();
+    return array.filter((item) => {
+      const k = key(item);
+      if (seen.has(k)) {
+        return false;
+      }
+      seen.add(k);
+      return true;
+    });
+  }
 }

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import { readFile, writeFile } from "node:fs/promises";
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
@@ -10,19 +9,10 @@ export default defineConfig({
     sourcemap: process.argv.slice(2).includes("--sourcemap"),
   },
   hooks: {
-    async "build:done"() {
+    "build:done"() {
       fs.appendFileSync(
         "./dist/index.d.ts",
         `\nimport type {} from "@hiogawa/vite-plugin-fullstack/types";\n`,
-      );
-      // inline file content as raw string to allow downstream package `nitro` to bundle this plugin package
-      let pluginBundle = await readFile("dist/index.js", "utf-8");
-      await writeFile(
-        "dist/index.js",
-        pluginBundle.replace(
-          `fs.readFileSync(path.join(import.meta.dirname, "runtime.js"), "utf-8")`,
-          `\`${await readFile("dist/runtime.js", "utf-8")}\``,
-        ),
       );
     },
   },

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -3,7 +3,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/runtime.ts"],
+  entry: ["src/index.ts", "src/assets.ts", "src/runtime.ts"],
   format: ["esm"],
   fixedExtension: false,
   dts: {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -16,14 +16,20 @@ export default defineConfig({
         `\nimport type {} from "@hiogawa/vite-plugin-fullstack/types";\n`,
       );
       // inline file content as raw string to allow downstream package `nitro` to bundle this plugin package
-      let pluginBundle = await readFile("dist/index.js", "utf-8");
-      await writeFile(
-        "dist/index.js",
-        pluginBundle.replace(
-          `fs.readFileSync(path.join(import.meta.dirname, "runtime.js"), "utf-8")`,
-          `\`${await readFile("dist/runtime.js", "utf-8")}\``,
-        ),
-      );
+      const pluginChunk = fs
+        .readdirSync("dist")
+        .find((f) => f.startsWith("plugin-") && f.endsWith(".js"));
+      if (pluginChunk) {
+        const pluginPath = `dist/${pluginChunk}`;
+        let pluginBundle = await readFile(pluginPath, "utf-8");
+        await writeFile(
+          pluginPath,
+          pluginBundle.replace(
+            `fs.readFileSync(path.join(import.meta.dirname, "runtime.js"), "utf-8")`,
+            `\`${await readFile("dist/runtime.js", "utf-8")}\``,
+          ),
+        );
+      }
     },
   },
 }) as any;

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -16,20 +16,14 @@ export default defineConfig({
         `\nimport type {} from "@hiogawa/vite-plugin-fullstack/types";\n`,
       );
       // inline file content as raw string to allow downstream package `nitro` to bundle this plugin package
-      const pluginChunk = fs
-        .readdirSync("dist")
-        .find((f) => f.startsWith("plugin-") && f.endsWith(".js"));
-      if (pluginChunk) {
-        const pluginPath = `dist/${pluginChunk}`;
-        let pluginBundle = await readFile(pluginPath, "utf-8");
-        await writeFile(
-          pluginPath,
-          pluginBundle.replace(
-            `fs.readFileSync(path.join(import.meta.dirname, "runtime.js"), "utf-8")`,
-            `\`${await readFile("dist/runtime.js", "utf-8")}\``,
-          ),
-        );
-      }
+      let pluginBundle = await readFile("dist/index.js", "utf-8");
+      await writeFile(
+        "dist/index.js",
+        pluginBundle.replace(
+          `fs.readFileSync(path.join(import.meta.dirname, "runtime.js"), "utf-8")`,
+          `\`${await readFile("dist/runtime.js", "utf-8")}\``,
+        ),
+      );
     },
   },
 }) as any;


### PR DESCRIPTION
## Summary
- Move `vitePluginFullstack` and `serverHandlerPlugin` to `src/plugins/fullstack.ts`
- Create `AssetsPluginOptions` type for `assetsPlugin`
- Add `src/assets.ts` with `assetsPlugin` as default export
- Export `/assets` subpath for standalone usage

Closes #3

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)