### PR TITLE
fix: auto extend ambient types in `/assets` exports

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
@@ -9,11 +10,13 @@ export default defineConfig({
     sourcemap: process.argv.slice(2).includes("--sourcemap"),
   },
   hooks: {
-    "build:done"() {
-      fs.appendFileSync(
-        "./dist/index.d.ts",
-        `\nimport type {} from "@hiogawa/vite-plugin-fullstack/types";\n`,
-      );
+    "build:done"(ctx) {
+      for (const filename of ["index.d.ts", "assets.d.ts"]) {
+        fs.appendFileSync(
+          path.join(ctx.options.outDir, filename),
+          `\nimport type {} from "@hiogawa/vite-plugin-fullstack/types";\n`,
+        );
+      }
     },
   },
 }) as any;


### PR DESCRIPTION
It's found that the ambient type is not extended with `/assets` https://github.com/nitrojs/nitro/pull/3891